### PR TITLE
Added ability to specify custom namespace

### DIFF
--- a/charts/micro/Chart.yaml
+++ b/charts/micro/Chart.yaml
@@ -3,7 +3,7 @@ name: micro
 description: Micro is a platform for cloud native microservices development. Install Micro on Kubernetes in one command.
 type: application
 appVersion: 3.1.1
-version: 3.0.0
+version: 2.0.0
 home: https://micro.mu
 keywords:
 - platform

--- a/charts/micro/Chart.yaml
+++ b/charts/micro/Chart.yaml
@@ -3,7 +3,7 @@ name: micro
 description: Micro is a platform for cloud native microservices development. Install Micro on Kubernetes in one command.
 type: application
 appVersion: 3.1.1
-version: 1.2.1
+version: 3.0.0
 home: https://micro.mu
 keywords:
 - platform

--- a/charts/micro/templates/deployment.yaml
+++ b/charts/micro/templates/deployment.yaml
@@ -1,17 +1,19 @@
+{{ if .createNamespace }}
 kind: Namespace
 apiVersion: v1
 metadata:
   name: micro
+{{ end }}
 ---
 kind: PersistentVolume
 apiVersion: v1
 metadata:
   name: store-pv
-  namespace: micro
+  namespace: "{{ if not .createNamespace }}{{.Release.Namespace}}{{else}}micro{{end}}"
 spec:
   claimRef:
     name: store-pvc
-    namespace: micro
+    namespace: "{{ if not .createNamespace }}{{.Release.Namespace}}{{else}}micro{{end}}"
   storageClassName: standard
   capacity:
     storage: 3Gi
@@ -24,7 +26,7 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: store-pvc
-  namespace: micro
+  namespace: "{{ if not .createNamespace }}{{.Release.Namespace}}{{else}}micro{{end}}"
 spec:
   storageClassName: standard
   accessModes:
@@ -37,13 +39,13 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: micro
-  namespace: micro
+  namespace: "{{ if not .createNamespace }}{{.Release.Namespace}}{{else}}micro{{end}}"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: micro
-  namespace: micro
+  namespace: "{{ if not .createNamespace }}{{.Release.Namespace}}{{else}}micro{{end}}"
 rules:
 - apiGroups:
   - ""
@@ -101,11 +103,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: micro
-  namespace: micro
+  namespace: "{{ if not .createNamespace }}{{.Release.Namespace}}{{else}}micro{{end}}"
 subjects:
 - kind: ServiceAccount
   name: micro
-  namespace: micro
+  namespace: "{{ if not .createNamespace }}{{.Release.Namespace}}{{else}}micro{{end}}"
 roleRef:
   kind: ClusterRole
   name: micro
@@ -115,7 +117,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: micro
-  namespace: micro
+  namespace: "{{ if not .createNamespace }}{{.Release.Namespace}}{{else}}micro{{end}}"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -127,8 +129,8 @@ subjects:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  namespace: micro
   name: micro
+  namespace: "{{ if not .createNamespace }}{{.Release.Namespace}}{{else}}micro{{end}}"
 spec:
   template:
     spec:

--- a/charts/micro/templates/deployment.yaml
+++ b/charts/micro/templates/deployment.yaml
@@ -1,4 +1,4 @@
-{{ if .createNamespace }}
+{{ if .Values.createNamespace }}
 kind: Namespace
 apiVersion: v1
 metadata:
@@ -9,11 +9,11 @@ kind: PersistentVolume
 apiVersion: v1
 metadata:
   name: store-pv
-  namespace: "{{ if not .createNamespace }}{{.Release.Namespace}}{{else}}micro{{end}}"
+  namespace: "{{ if not .Values.createNamespace }}{{.Release.Namespace}}{{else}}micro{{end}}"
 spec:
   claimRef:
     name: store-pvc
-    namespace: "{{ if not .createNamespace }}{{.Release.Namespace}}{{else}}micro{{end}}"
+    namespace: "{{ if not .Values.createNamespace }}{{.Release.Namespace}}{{else}}micro{{end}}"
   storageClassName: standard
   capacity:
     storage: 3Gi
@@ -26,7 +26,7 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: store-pvc
-  namespace: "{{ if not .createNamespace }}{{.Release.Namespace}}{{else}}micro{{end}}"
+  namespace: "{{ if not .Values.createNamespace }}{{.Release.Namespace}}{{else}}micro{{end}}"
 spec:
   storageClassName: standard
   accessModes:
@@ -39,13 +39,13 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: micro
-  namespace: "{{ if not .createNamespace }}{{.Release.Namespace}}{{else}}micro{{end}}"
+  namespace: "{{ if not .Values.createNamespace }}{{.Release.Namespace}}{{else}}micro{{end}}"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: micro
-  namespace: "{{ if not .createNamespace }}{{.Release.Namespace}}{{else}}micro{{end}}"
+  namespace: "{{ if not .Values.createNamespace }}{{.Release.Namespace}}{{else}}micro{{end}}"
 rules:
 - apiGroups:
   - ""
@@ -103,11 +103,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: micro
-  namespace: "{{ if not .createNamespace }}{{.Release.Namespace}}{{else}}micro{{end}}"
+  namespace: "{{ if not .Values.createNamespace }}{{.Release.Namespace}}{{else}}micro{{end}}"
 subjects:
 - kind: ServiceAccount
   name: micro
-  namespace: "{{ if not .createNamespace }}{{.Release.Namespace}}{{else}}micro{{end}}"
+  namespace: "{{ if not .Values.createNamespace }}{{.Release.Namespace}}{{else}}micro{{end}}"
 roleRef:
   kind: ClusterRole
   name: micro
@@ -117,7 +117,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: micro
-  namespace: "{{ if not .createNamespace }}{{.Release.Namespace}}{{else}}micro{{end}}"
+  namespace: "{{ if not .Values.createNamespace }}{{.Release.Namespace}}{{else}}micro{{end}}"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -130,7 +130,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: micro
-  namespace: "{{ if not .createNamespace }}{{.Release.Namespace}}{{else}}micro{{end}}"
+  namespace: "{{ if not .Values.createNamespace }}{{.Release.Namespace}}{{else}}micro{{end}}"
 spec:
   template:
     spec:

--- a/charts/micro/templates/deployment.yaml
+++ b/charts/micro/templates/deployment.yaml
@@ -135,7 +135,7 @@ spec:
         - name: MICRO_PROFILE
           value: kubernetes
         - name: MICRO_PROXY
-          value: "network.micro.svc.cluster.local:8443"
+          value: "network.{{.Release.Namespace}}.svc.cluster.local:8443"
         - name: MICRO_SERVER_IMAGE
           value: "{{ .Values.image.repo }}:{{ .Values.image.tag }}"
         args:

--- a/charts/micro/templates/deployment.yaml
+++ b/charts/micro/templates/deployment.yaml
@@ -1,19 +1,13 @@
-{{ if .Values.createNamespace }}
-kind: Namespace
-apiVersion: v1
-metadata:
-  name: micro
-{{ end }}
 ---
 kind: PersistentVolume
 apiVersion: v1
 metadata:
   name: store-pv
-  namespace: "{{ if not .Values.createNamespace }}{{.Release.Namespace}}{{else}}micro{{end}}"
+  namespace: "{{.Release.Namespace}}"
 spec:
   claimRef:
     name: store-pvc
-    namespace: "{{ if not .Values.createNamespace }}{{.Release.Namespace}}{{else}}micro{{end}}"
+    namespace: "{{.Release.Namespace}}"
   storageClassName: standard
   capacity:
     storage: 3Gi
@@ -26,7 +20,7 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: store-pvc
-  namespace: "{{ if not .Values.createNamespace }}{{.Release.Namespace}}{{else}}micro{{end}}"
+  namespace: "{{.Release.Namespace}}"
 spec:
   storageClassName: standard
   accessModes:
@@ -39,13 +33,13 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: micro
-  namespace: "{{ if not .Values.createNamespace }}{{.Release.Namespace}}{{else}}micro{{end}}"
+  namespace: "{{.Release.Namespace}}"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: micro
-  namespace: "{{ if not .Values.createNamespace }}{{.Release.Namespace}}{{else}}micro{{end}}"
+  namespace: "{{.Release.Namespace}}"
 rules:
 - apiGroups:
   - ""
@@ -103,11 +97,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: micro
-  namespace: "{{ if not .Values.createNamespace }}{{.Release.Namespace}}{{else}}micro{{end}}"
+  namespace: "{{.Release.Namespace}}"
 subjects:
 - kind: ServiceAccount
   name: micro
-  namespace: "{{ if not .Values.createNamespace }}{{.Release.Namespace}}{{else}}micro{{end}}"
+  namespace: "{{.Release.Namespace}}"
 roleRef:
   kind: ClusterRole
   name: micro
@@ -117,7 +111,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: micro
-  namespace: "{{ if not .Values.createNamespace }}{{.Release.Namespace}}{{else}}micro{{end}}"
+  namespace: "{{.Release.Namespace}}"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -130,7 +124,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: micro
-  namespace: "{{ if not .Values.createNamespace }}{{.Release.Namespace}}{{else}}micro{{end}}"
+  namespace: "{{.Release.Namespace}}"
 spec:
   template:
     spec:

--- a/charts/micro/values.yaml
+++ b/charts/micro/values.yaml
@@ -1,6 +1,8 @@
 # Default values for micro.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
-image: 
+image:
   repo: micro/micro
   tag: latest
+
+createNamespace: false

--- a/charts/micro/values.yaml
+++ b/charts/micro/values.yaml
@@ -4,5 +4,3 @@
 image:
   repo: micro/micro
   tag: latest
-
-createNamespace: false


### PR DESCRIPTION
## Changes

- Defaults to user-provided namespace from `{{.Release.Namespace}}`
- Bumps the chart version to `2.0.0` since this could be a breaking change for some people expecting it to default to use the `micro` namespace.

## Notes

This chart now acts more like expected and will default to the `default` namespace unless specified to be another namespace. It will also now respect namespace settings applied in a helmrelease yaml manifest.

Please feel free to make any edits to this pull request or let me know if there's anything you'd like changed!